### PR TITLE
Close curly brace, improve readability in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Example front-end dev workflow:
 3. Run npm run build
 4. Uninstall the current version of this application on your arches instance with 
 ```pip uninstall archesdataviewer```
-1. Reinstall the application with ```pip install git+https://github.com/{yourgithubforkurl```
+1. Reinstall the application with ```pip install git+https://github.com/{YourGithubForkURL}```


### PR DESCRIPTION
There was a closing curly brace missing on the example `pip install` line, so this change adds that brace.  But also, the undifferentiated string "yourgithubforkurl" had the potential to fool the eye -- when I was just skimming, I at first read it as "your github for kurl", and thought the last word was an intentional fun misspelling of "curl". Then when I looked more closely I realized what the string meant.  So this change also puts the string in StudlyCaps to improve readability.