### PR TITLE
Add Resource Relation Type

### DIFF
--- a/front-end/src/types/ResourceRelation.ts
+++ b/front-end/src/types/ResourceRelation.ts
@@ -1,0 +1,43 @@
+import type { Point, MapPopup, Geometry, ResourcePermissions } from './SearchResult';
+
+interface RelationIds {
+  id: string;
+  nodegroup_id: string;
+  provisional: boolean;
+}
+
+interface RelationDomain {
+  conceptid: string;
+  label: string;
+  nodegroup_id: string;
+  provisional: boolean;
+  valueid: string;
+}
+
+interface ResourceRelation {
+  date_ranges: string[];
+  dates: string[];
+  displaydescription: string;
+  displayname: string;
+  domains: RelationDomain[];
+  geometries: Geometry[];
+  graph_id: string;
+  ids: RelationIds[];
+  legacyid: null;
+  map_popup: MapPopup[];
+  numbers: any[];
+  permissions: ResourcePermissions;
+  points: Point[];
+  provisional_resource: string;
+  resourceinstanceid: string;
+  root_ontology_class: string;
+  strings?: any;
+  tiles?: any;
+  total_relations: number;
+}
+
+interface ResourceRelationArray {
+  items: ResourceRelation[];
+}
+
+export type { ResourceRelation, ResourceRelationArray };

--- a/front-end/src/types/SearchResult.ts
+++ b/front-end/src/types/SearchResult.ts
@@ -37,6 +37,13 @@ interface Point {
   provisional: boolean;
 }
 
+interface ResourcePermissions {
+  users_with_no_access: string[];
+  users_without_delete_perm: string[];
+  users_without_edit_perm: string[];
+  users_without_read_perm: string[];
+}
+
 interface SearchResult {
   _id: string;
   _index: string;
@@ -48,7 +55,7 @@ interface SearchResult {
     geometries: Geometry[];
     graph_id: string;
     map_popup: MapPopup[] | string;
-    permissions: Permissions;
+    permissions: ResourcePermissions;
     points: Point[];
     provisional_resource: string;
     resourceinstanceid: string;
@@ -60,4 +67,4 @@ interface SearchResult {
 interface SearchResultArray {
   items: SearchResult[];
 }
-export type { MapPopup, SearchResult, SearchResultArray };
+export type { ResourcePermissions, Point, Geometry, MapPopup, SearchResult, SearchResultArray };

--- a/front-end/src/types/index.ts
+++ b/front-end/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './SearchResult';
 export * from './Artist';
 export * from './Artwork';
+export * from './ResourceRelation';


### PR DESCRIPTION
This commit adds a type for a related resource, as returned by the '/resources/related' endpoint in the Arches API