### PR TITLE
Add ajv type validation

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -8,6 +8,7 @@
       "name": "front-end",
       "version": "0.0.0",
       "dependencies": {
+        "ajv": "^8.16.0",
         "leaflet": "^1.9.4",
         "vue": "^3.4.21"
       },
@@ -455,6 +456,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -464,6 +481,12 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -1254,15 +1277,14 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
       },
       "funding": {
         "type": "github",
@@ -1688,6 +1710,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1697,6 +1735,12 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -1777,8 +1821,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -2153,10 +2196,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2584,7 +2626,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2620,6 +2661,14 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2909,7 +2958,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "ajv": "^8.16.0",
     "leaflet": "^1.9.4",
     "vue": "^3.4.21"
   },

--- a/front-end/src/ajv.ts
+++ b/front-end/src/ajv.ts
@@ -1,0 +1,5 @@
+import Ajv from 'ajv';
+
+export const ajv = new Ajv({
+	coerceTypes: true,
+});

--- a/front-end/src/ajv.ts
+++ b/front-end/src/ajv.ts
@@ -1,5 +1,5 @@
 import Ajv from 'ajv';
 
 export const ajv = new Ajv({
-	coerceTypes: true,
+  coerceTypes: true
 });

--- a/front-end/src/types/Artist.ts
+++ b/front-end/src/types/Artist.ts
@@ -1,13 +1,45 @@
-import type { MapPopup } from './SearchResult';
+import type { JSONSchemaType } from 'ajv';
+import { ajv } from '@/ajv';
+import { MapPopupSchema, type MapPopup } from './SearchResult';
 
 export interface Artist {
   displaydescription: string;
   displayname: string;
   graph_id: string;
-  legacyid?: null;
   map_popup: MapPopup[] | string;
   resource: {
     Name: string;
   };
   resourceinstanceid: string;
 }
+const ArtistSchema: JSONSchemaType<Artist> = {
+  type: 'object',
+  properties: {
+    displaydescription: { type: 'string' },
+    displayname: { type: 'string' },
+    graph_id: { type: 'string' },
+    map_popup: {
+      oneOf: [{ type: 'array', items: MapPopupSchema }, { type: 'string' }]
+    },
+    resource: {
+      type: 'object',
+      properties: {
+        Name: { type: 'string' }
+      },
+      required: ['Name'],
+      additionalProperties: true
+    },
+    resourceinstanceid: { type: 'string' }
+  },
+  required: [
+    'displaydescription',
+    'displayname',
+    'graph_id',
+    'map_popup',
+    'resource',
+    'resourceinstanceid'
+  ],
+  additionalProperties: true
+};
+
+export const validateArtistSchema = ajv.compile(ArtistSchema);

--- a/front-end/src/types/Artwork.ts
+++ b/front-end/src/types/Artwork.ts
@@ -1,3 +1,6 @@
+import type { JSONSchemaType } from 'ajv';
+import { ajv } from '@/ajv';
+
 interface ArtworkResource {
   Artist: string;
   Identifiers: {
@@ -21,8 +24,66 @@ export interface Artwork {
   displaydescription: string;
   displayname: string;
   graph_id: string;
-  legacyid?: any;
   map_popup: string;
   resource: ArtworkResource;
   resourceinstanceid: string;
 }
+
+const ArtworkResourceSchema: JSONSchemaType<ArtworkResource> = {
+  type: 'object',
+  properties: {
+    Artist: { type: 'string' },
+    Identifiers: {
+      type: 'object',
+      properties: {
+        ID: { type: 'string' },
+        'ID Type': { type: 'string' }
+      },
+      required: ['ID', 'ID Type']
+    },
+    Image: {
+      type: 'object',
+      properties: {
+        '@value': { type: 'string' },
+        Photographer: { type: 'string' }
+      },
+      required: ['@value', 'Photographer']
+    },
+    Location: {
+      type: 'object',
+      properties: {
+        Address: { type: 'string' },
+        Coordinates: { type: 'string' },
+        'Location Description': { type: 'string' },
+        Structure: { type: 'string' }
+      },
+      required: ['Address', 'Coordinates', 'Location Description', 'Structure']
+    },
+    Title: { type: 'string' }
+  },
+  required: ['Artist', 'Identifiers', 'Image', 'Location', 'Title'],
+  additionalProperties: true
+};
+
+const ArtworkSchema: JSONSchemaType<Artwork> = {
+  type: 'object',
+  properties: {
+    displaydescription: { type: 'string' },
+    displayname: { type: 'string' },
+    graph_id: { type: 'string' },
+    map_popup: { type: 'string' },
+    resource: ArtworkResourceSchema,
+    resourceinstanceid: { type: 'string' }
+  },
+  required: [
+    'displaydescription',
+    'displayname',
+    'graph_id',
+    'map_popup',
+    'resource',
+    'resourceinstanceid'
+  ],
+  additionalProperties: true
+};
+
+export const validateArtworkSchema = ajv.compile(ArtworkSchema);

--- a/front-end/src/types/SearchResult.ts
+++ b/front-end/src/types/SearchResult.ts
@@ -1,3 +1,4 @@
+import type { JSONSchemaType } from 'ajv';
 /*
  * Modeled off the results of a GET request to the
  * /search/resources endpoint!
@@ -67,4 +68,16 @@ interface SearchResult {
 interface SearchResultArray {
   items: SearchResult[];
 }
+
+const MapPopupSchema: JSONSchemaType<MapPopup> = {
+  type: 'object',
+  properties: {
+    language: { type: 'string' },
+    value: { type: 'string' }
+  },
+  required: ['language', 'value']
+};
+
 export type { ResourcePermissions, Point, Geometry, MapPopup, SearchResult, SearchResultArray };
+
+export { MapPopupSchema };


### PR DESCRIPTION
This PR introduces the [ajv library](https://ajv.js.org/) to the project which, among other things, provides a straightforward manner to implement [typeguards](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types), a typescript solution to type validation at runtime. This infrastructure will be good to have in the project longterm as types grow more complex, and in the immediate it has been implemented on the 'Artist' and 'Artwork' resource types, so as to differentiate between the two at runtime. 