### PR TITLE
Add arches meta data option

### DIFF
--- a/front-end/src/components/ArtistDetail.vue
+++ b/front-end/src/components/ArtistDetail.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="artist-detail">
-    <h1>{{ props.artist.displayname }}</h1>
-    <h2>{{ props.artist.displaydescription }}</h2>
+    <h1>Artist Name: {{ props.artist.Name }}</h1>
   </div>
 </template>
 

--- a/front-end/src/components/ArtworkDetail.vue
+++ b/front-end/src/components/ArtworkDetail.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="artwork-detail">
-    <h1>{{ props.artwork.displayname }}</h1>
-    <h2>{{ props.artwork.displaydescription }}</h2>
+    <h1>Artist: {{ props.artwork.Artist }}</h1>
+    <h2>Description: {{ props.artwork?.Description }}</h2>
     <img :src="imagesrc" alt="artwork image" />
-    <h3>Photographer: {{ props.artwork.resource?.Image?.Photographer }}</h3>
+    <h3>Photographer: {{ props.artwork.Image?.Photographer }}</h3>
   </div>
 </template>
 
@@ -16,8 +16,8 @@ const props = defineProps<{
 }>();
 
 const imagesrc = computed(() => {
-  if (props.artwork.resource.Image) {
-    return `${import.meta.env.VITE_ARCHES_API_URL}${props.artwork.resource.Image['@value']}`;
+  if (props.artwork.Image) {
+    return `${import.meta.env.VITE_ARCHES_API_URL}${props.artwork.Image['@value']}`;
   } else {
     return '';
   }

--- a/front-end/src/components/ResourcePanel.vue
+++ b/front-end/src/components/ResourcePanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import { validateArtistSchema, validateArtworkSchema } from '@/types';
-import ResourceDetailProvider from './ResourcePanelProvider.vue';
 import ArtworkDetail from './ArtworkDetail.vue';
 import ArtistDetail from './ArtistDetail.vue';
 import type { Resource } from '@/types';
@@ -8,11 +8,13 @@ import type { Resource } from '@/types';
 const props = defineProps<{
   resource: Resource | undefined;
 }>();
+
+const showMetaData = ref<boolean>(false);
 </script>
 
 <template>
   <div id="resource-panel">
-    <div v-if="props.resource">
+    <div v-if="props.resource !== undefined">
       <ArtworkDetail
         :artwork="props.resource.resource"
         v-if="validateArtworkSchema(props.resource?.resource)"
@@ -21,6 +23,13 @@ const props = defineProps<{
         :artist="props.resource.resource"
         v-else-if="validateArtistSchema(props.resource?.resource)"
       />
+      <button @click="showMetaData = !showMetaData">Show Arches Metadata</button>
+      <div v-if="showMetaData">
+        <ul>
+          <li>Graph Id: {{ props.resource.graph_id }}</li>
+          <li>Resource Instance Id: {{ props.resource.resourceinstanceid }}</li>
+        </ul>
+      </div>
     </div>
     <div v-else>
       <p>Click on a resource on the map or search list to display details</p>
@@ -36,6 +45,5 @@ const props = defineProps<{
     0 4px 8px 0 rgba(0, 0, 0, 0.2),
     0 6px 20px 0 rgba(0, 0, 0, 0.19);
   width: 80%;
-  height: 50%;
 }
 </style>

--- a/front-end/src/components/ResourcePanel.vue
+++ b/front-end/src/components/ResourcePanel.vue
@@ -1,16 +1,30 @@
 <script setup lang="ts">
 import { validateArtistSchema, validateArtworkSchema } from '@/types';
-import ResourceDetailProvider from './ResourceDetailProvider.vue';
+import ResourceDetailProvider from './ResourcePanelProvider.vue';
 import ArtworkDetail from './ArtworkDetail.vue';
 import ArtistDetail from './ArtistDetail.vue';
+import type { Resource } from '@/types';
+
+const props = defineProps<{
+  resource: Resource | undefined;
+}>();
 </script>
 
 <template>
   <div id="resource-panel">
-    <ResourceDetailProvider v-slot="{ resource }">
-      <ArtworkDetail :artwork="resource" v-if="validateArtworkSchema(resource)" />
-      <ArtistDetail :artist="resource" v-else-if="validateArtistSchema(resource)" />
-    </ResourceDetailProvider>
+    <div v-if="props.resource">
+      <ArtworkDetail
+        :artwork="props.resource.resource"
+        v-if="validateArtworkSchema(props.resource?.resource)"
+      />
+      <ArtistDetail
+        :artist="props.resource.resource"
+        v-else-if="validateArtistSchema(props.resource?.resource)"
+      />
+    </div>
+    <div v-else>
+      <p>Click on a resource on the map or search list to display details</p>
+    </div>
   </div>
 </template>
 

--- a/front-end/src/components/ResourcePanelProvider.vue
+++ b/front-end/src/components/ResourcePanelProvider.vue
@@ -5,8 +5,9 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 import { useResourceStore } from '../stores/resourceStore';
+import type { Resource } from '@/types';
 const store = useResourceStore();
-const resource = ref(null);
+const resource = ref<Resource>();
 
 async function fetchResource() {
   if (!store.resourceId) return;

--- a/front-end/src/components/SearchListItem.vue
+++ b/front-end/src/components/SearchListItem.vue
@@ -2,16 +2,6 @@
   <div class="search-list-item">
     <h1>{{ `${props.result._source.displayname}` }}</h1>
     <h2>Description: {{ props.result._source.displaydescription }}</h2>
-    <ul>
-      <li>Language: {{ props.result._source.displaydescription }}</li>
-      <li>
-        Root Ontology Class:
-        <a :href="props.result._source.root_ontology_class">{{
-          props.result._source.root_ontology_class
-        }}</a>
-      </li>
-      <li>Is Provisional Resource?: {{ props.result._source.provisional_resource }}</li>
-    </ul>
     <button @click="setResource" class="details-button">details</button>
   </div>
 </template>

--- a/front-end/src/pages/HomePage.vue
+++ b/front-end/src/pages/HomePage.vue
@@ -26,10 +26,9 @@ import ResourcePanelProvider from '@/components/ResourcePanelProvider.vue';
       </LeafletMapProvider>
     </div>
     <div class="column" id="resource-panel-container">
-      <ResourcePanelProvider v-slot="{resource }">
+      <ResourcePanelProvider v-slot="{ resource }">
         <ResourcePanel :resource="resource" />
       </ResourcePanelProvider>
-      </div
     </div>
   </div>
 </template>

--- a/front-end/src/pages/HomePage.vue
+++ b/front-end/src/pages/HomePage.vue
@@ -4,6 +4,7 @@ import SearchList from '../components/SearchList.vue';
 import LeafletMapProvider from '../components/LeafletMapProvider.vue';
 import LeafletMap from '../components/LeafletMap.vue';
 import ResourcePanel from '../components/ResourcePanel.vue';
+import ResourcePanelProvider from '@/components/ResourcePanelProvider.vue';
 </script>
 
 <template>
@@ -25,7 +26,10 @@ import ResourcePanel from '../components/ResourcePanel.vue';
       </LeafletMapProvider>
     </div>
     <div class="column" id="resource-panel-container">
-      <ResourcePanel />
+      <ResourcePanelProvider v-slot="{resource }">
+        <ResourcePanel :resource="resource" />
+      </ResourcePanelProvider>
+      </div
     </div>
   </div>
 </template>

--- a/front-end/src/types/Artist.ts
+++ b/front-end/src/types/Artist.ts
@@ -1,44 +1,16 @@
 import type { JSONSchemaType } from 'ajv';
 import { ajv } from '@/ajv';
-import { MapPopupSchema, type MapPopup } from './SearchResult';
 
 export interface Artist {
-  displaydescription: string;
-  displayname: string;
-  graph_id: string;
-  map_popup: MapPopup[] | string;
-  resource: {
-    Name: string;
-  };
-  resourceinstanceid: string;
+  Name: string;
 }
+
 const ArtistSchema: JSONSchemaType<Artist> = {
   type: 'object',
   properties: {
-    displaydescription: { type: 'string' },
-    displayname: { type: 'string' },
-    graph_id: { type: 'string' },
-    map_popup: {
-      oneOf: [{ type: 'array', items: MapPopupSchema }, { type: 'string' }]
-    },
-    resource: {
-      type: 'object',
-      properties: {
-        Name: { type: 'string' }
-      },
-      required: ['Name'],
-      additionalProperties: true
-    },
-    resourceinstanceid: { type: 'string' }
+    Name: { type: 'string' }
   },
-  required: [
-    'displaydescription',
-    'displayname',
-    'graph_id',
-    'map_popup',
-    'resource',
-    'resourceinstanceid'
-  ],
+  required: ['Name'],
   additionalProperties: true
 };
 

--- a/front-end/src/types/Artwork.ts
+++ b/front-end/src/types/Artwork.ts
@@ -1,7 +1,7 @@
 import type { JSONSchemaType } from 'ajv';
 import { ajv } from '@/ajv';
 
-interface ArtworkResource {
+export interface Artwork {
   Artist: string;
   Identifiers: {
     ID: string;
@@ -17,22 +17,15 @@ interface ArtworkResource {
     'Location Description': string;
     Structure: string;
   };
+  Description?: string;
   Title: string;
 }
 
-export interface Artwork {
-  displaydescription: string;
-  displayname: string;
-  graph_id: string;
-  map_popup: string;
-  resource: ArtworkResource;
-  resourceinstanceid: string;
-}
-
-const ArtworkResourceSchema: JSONSchemaType<ArtworkResource> = {
+const ArtworkSchema: JSONSchemaType<Artwork> = {
   type: 'object',
   properties: {
     Artist: { type: 'string' },
+    Description: { type: 'string', nullable: true },
     Identifiers: {
       type: 'object',
       properties: {
@@ -61,28 +54,7 @@ const ArtworkResourceSchema: JSONSchemaType<ArtworkResource> = {
     },
     Title: { type: 'string' }
   },
-  required: ['Artist', 'Identifiers', 'Image', 'Location', 'Title'],
-  additionalProperties: true
-};
-
-const ArtworkSchema: JSONSchemaType<Artwork> = {
-  type: 'object',
-  properties: {
-    displaydescription: { type: 'string' },
-    displayname: { type: 'string' },
-    graph_id: { type: 'string' },
-    map_popup: { type: 'string' },
-    resource: ArtworkResourceSchema,
-    resourceinstanceid: { type: 'string' }
-  },
-  required: [
-    'displaydescription',
-    'displayname',
-    'graph_id',
-    'map_popup',
-    'resource',
-    'resourceinstanceid'
-  ],
+  required: ['Artist', 'Identifiers', 'Location', 'Title'],
   additionalProperties: true
 };
 

--- a/front-end/src/types/Resource.ts
+++ b/front-end/src/types/Resource.ts
@@ -1,0 +1,11 @@
+import type { Artist } from './Artist';
+import type { Artwork } from './Artwork';
+
+export interface Resource {
+  displaydescription: string;
+  displayname: string;
+  graph_id: string;
+  map_popup: string;
+  resource: Artist | Artwork;
+  resourceinstanceid: string;
+}

--- a/front-end/src/types/index.ts
+++ b/front-end/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './SearchResult';
 export * from './Artist';
 export * from './Artwork';
 export * from './ResourceRelation';
+export * from './Resource';


### PR DESCRIPTION
This PR adds the ability for a user to choose whether or not to view certain arches metadata surrounding a resource. It also refactors the existing Artist and Artwork types, which represent specific resource models in our arches instance, specifying them and abstracting their shared fields into a generic Resource type. 