### PR TITLE
Add Custom Django Artwork Map Route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+archesdataviewer.egg-info/

--- a/archesdataviewer/urls.py
+++ b/archesdataviewer/urls.py
@@ -1,7 +1,10 @@
-from django.urls import re_path
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
-    re_path(r"^archesdataviewer/", views.index, name="archesdataviewer"),
+    path('archesdataviewer/', views.index, name='archesdataviewer'),
+    path('archesdataviewer/artworks', views.artworksmap, name='artworksmap'),
+    path('archesdataviewer/graphs', views.graphs, name='graphs'),
 ]
+

--- a/archesdataviewer/views.py
+++ b/archesdataviewer/views.py
@@ -1,17 +1,75 @@
 import json
 from django.shortcuts import render
+from arches.app.models import models
+from arches.app.models.resource import Resource
+from arches.app.utils.response import JSONResponse
+from arches.app.utils.betterJSONSerializer import JSONSerializer
+
+# This is a prefetch done to the GraphModel to allow for ease of lookup
+# for a given Resource model
+graphs_prefetch = models.GraphModel.objects.all()
+name_to_graph_table = {str(gr_obj.name): gr_obj for gr_obj in graphs_prefetch}
+
 
 def index(request):
-    with open('/usr/local/lib/python3.10/site-packages/archesdataviewer/static/.vite/manifest.json', 'r') as manifest:
+    with open(
+        "/usr/local/lib/python3.10/site-packages/archesdataviewer/static/.vite/manifest.json",
+        "r",
+    ) as manifest:
         json_data = json.load(manifest)
-    
+
     # Extract relevant data from the JSON
-    js_file = json_data['index.html']['file']
-    css_file = json_data['index.html']['css'][0]
-    
+    js_file = json_data["index.html"]["file"]
+    css_file = json_data["index.html"]["css"][0]
+
     context = {
-        'js_file': js_file,
-        'css_file': css_file,
+        "js_file": js_file,
+        "css_file": css_file,
     }
-    
-    return render(request, 'index.html', context)
+
+    return render(request, "index.html", context)
+
+
+# Helper function for combining a resource with it's GeoJson Data
+def create_artwork_geojson(resource: Resource, geojson_serialized):
+    resource_id = str(resource.resourceinstanceid)
+    geojson = geojson_serialized.get(resource_id)
+    if geojson:
+        return {
+            "resourceinstanceid": resource_id,
+            "graph_id": str(resource.graph_id),
+            "name": str(resource.name),
+            "geojson": geojson,
+        }
+    return None
+
+
+# This is a custom route for returning a list of all Artwork Resources paired with their geojson data (if such data exists)
+# It makes two requests to the database, gathering all Artwork Resources and GeoJSONGeometry model instances
+# It returns only enough data to render the Artworks on a map, which is currently the artwork name, it's resourceId,
+# graphId, and geojson data.
+def artworksmap(request):
+    # Gather all artwork resources and geojson objects
+    artwork_resources = Resource.objects.filter(graph=name_to_graph_table["Artwork"])
+    geojson_objects = models.GeoJSONGeometry.objects.all()
+    geojson_serialized = {
+        str(geo["resourceinstance_id"]): geo
+        for geo in JSONSerializer().serializeToPython(geojson_objects)
+    }
+
+    # Return paired artworks with geojson data, based on resource_id field
+    artwork_geojson_data = [
+        create_artwork_geojson(resource, geojson_serialized)
+        for resource in artwork_resources
+        if create_artwork_geojson(resource, geojson_serialized) is not None
+    ]
+
+    return JSONResponse(artwork_geojson_data)
+
+
+# Custom Route for returning all graph id's and names, used by the front-end
+# component to distinguish resource types dynamically.
+def graphs(request):
+    return JSONResponse(
+        JSONSerializer().serializeToPython(models.GraphModel.objects.all())
+    )


### PR DESCRIPTION
This commit adds two new custom routes to the arches application, one that provides the active graphs and their ids, and one that returns a list of all artwork data combined with it's geojson data. This was decided on after concluding that the existing REST API infrastructure provided in base arches could not serve the goal of gathering all Artworks in a single API call.  It leverages the Django ORM and shared application resource store, and is notably the first time the project has directly pulled data from the arches application, as opposed to just consuming it on the front-end.