### PR TITLE
Fix Artwork Resource View

### DIFF
--- a/archesdataviewer/views.py
+++ b/archesdataviewer/views.py
@@ -30,41 +30,25 @@ def index(request):
     return render(request, "index.html", context)
 
 
-# Helper function for combining a resource with it's GeoJson Data
-def create_artwork_geojson(resource: Resource, geojson_serialized):
-    resource_id = str(resource.resourceinstanceid)
-    geojson = geojson_serialized.get(resource_id)
-    if geojson:
-        return {
-            "resourceinstanceid": resource_id,
-            "graph_id": str(resource.graph_id),
-            "name": str(resource.name),
-            "geojson": geojson,
-        }
-    return None
-
-
 # This is a custom route for returning a list of all Artwork Resources paired with their geojson data (if such data exists)
 # It makes two requests to the database, gathering all Artwork Resources and GeoJSONGeometry model instances
 # It returns only enough data to render the Artworks on a map, which is currently the artwork name, it's resourceId,
 # graphId, and geojson data.
 def artworksmap(request):
     # Gather all artwork resources and geojson objects
-    artwork_resources = Resource.objects.filter(graph=name_to_graph_table["Artwork"])
-    geojson_objects = models.GeoJSONGeometry.objects.all()
-    geojson_serialized = {
-        str(geo["resourceinstance_id"]): geo
-        for geo in JSONSerializer().serializeToPython(geojson_objects)
-    }
-
-    # Return paired artworks with geojson data, based on resource_id field
-    artwork_geojson_data = [
-        create_artwork_geojson(resource, geojson_serialized)
-        for resource in artwork_resources
-        if create_artwork_geojson(resource, geojson_serialized) is not None
-    ]
-
-    return JSONResponse(artwork_geojson_data)
+    artwork_resources = Resource.to_json__bulk(Resource.objects.filter(graph=name_to_graph_table["Artwork"]))
+    
+    # Parse into json, accounting for doubly nested json string
+    for resource in artwork_resources:
+        coordinates_str = resource.get('Location', {}).get('Coordinates')
+        if coordinates_str:
+            try:
+                coordinates_json = json.loads(coordinates_str.replace("'", "\""))
+                resource['Location']['Coordinates'] = coordinates_json
+            except json.JSONDecodeError:
+               resource['Location']['Coordinates'] = None
+               
+    return JSONResponse(artwork_resources)
 
 
 # Custom Route for returning all graph id's and names, used by the front-end


### PR DESCRIPTION
This commit trims the artwork resource route added in commit 20f7447d7a5130668e3d74e3f77266a5e4ade3c2, as it turns out that the geojson resource model was not needed to provide the necessary data. Instead, it adds an extra level of json processing to accomodate our Artwork Resource Model, and returns all Artwork metadata with a single request