### PR TITLE
Add Coordinates Type

### DIFF
--- a/front-end/src/types/Artwork.ts
+++ b/front-end/src/types/Artwork.ts
@@ -13,7 +13,7 @@ export interface Artwork {
   };
   Location: {
     Address: string;
-    Coordinates: string;
+    Coordinates?: string;
     'Location Description': string;
     Structure: string;
   };
@@ -46,15 +46,15 @@ const ArtworkSchema: JSONSchemaType<Artwork> = {
       type: 'object',
       properties: {
         Address: { type: 'string' },
-        Coordinates: { type: 'string' },
+        Coordinates: { type: 'string', nullable: true },
         'Location Description': { type: 'string' },
         Structure: { type: 'string' }
       },
-      required: ['Address', 'Coordinates', 'Location Description', 'Structure']
+      required: ['Address', 'Location Description', 'Structure']
     },
     Title: { type: 'string' }
   },
-  required: ['Artist', 'Identifiers', 'Location', 'Title'],
+  required: ['Artist', 'Identifiers', 'Title'],
   additionalProperties: true
 };
 

--- a/front-end/src/types/Coordinates.ts
+++ b/front-end/src/types/Coordinates.ts
@@ -1,0 +1,64 @@
+import type { JSONSchemaType } from 'ajv';
+import { ajv } from '@/ajv';
+
+interface Coordinates {
+  type: string;
+  features: Feature[];
+}
+
+interface Feature {
+  id: string;
+  type: string;
+  geometry: Geometry;
+  properties: Properties;
+  feature_info_content: string;
+}
+
+interface Geometry {
+  type: string;
+  coordinates: number[];
+}
+
+interface Properties {
+  nodeId: string;
+}
+const CoordinatesSchema: JSONSchemaType<Coordinates> = {
+  type: 'object',
+  properties: {
+    type: { type: 'string' },
+    features: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          type: { type: 'string' },
+          geometry: {
+            type: 'object',
+            properties: {
+              type: { type: 'string' },
+              coordinates: {
+                type: 'array',
+                items: { type: 'number' }
+              }
+            },
+            required: ['type', 'coordinates']
+          },
+          properties: {
+            type: 'object',
+            properties: {
+              nodeId: { type: 'string' }
+            },
+            required: ['nodeId']
+          },
+          feature_info_content: { type: 'string' }
+        },
+        required: ['id', 'type', 'geometry', 'properties', 'feature_info_content']
+      }
+    }
+  },
+  nullable: true,
+  required: ['type', 'features']
+};
+export type { Coordinates };
+export const validateCoordinatesSchema = ajv.compile(CoordinatesSchema);

--- a/front-end/src/types/index.ts
+++ b/front-end/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './Artist';
 export * from './Artwork';
 export * from './ResourceRelation';
 export * from './Resource';
+export * from './Coordinates'

--- a/front-end/src/utils.ts
+++ b/front-end/src/utils.ts
@@ -1,0 +1,16 @@
+import { validateCoordinatesSchema } from './types';
+import type { Coordinates } from './types';
+
+export function coordinatesStringToObject(coordinates: string): Coordinates {
+  const validJsonString = coordinates.replace(/'/g, '"');
+  try {
+    coordinates = JSON.parse(validJsonString);
+    if (validateCoordinatesSchema(coordinates)) {
+      return coordinates;
+    } else {
+      throw new Error('Coordinates JSON string invalid');
+    }
+  } catch (error) {
+    throw new Error('Failed to parse Coordinates JSON string');
+  }
+}


### PR DESCRIPTION
This commit adds the Coordinates type to the project, which is made to represent the parsed json from the coordinates field of an Artwork Resource from Arches. Currently, in the WAC arches instance, the coordinates field is returned from the arches API as a string literal, so for the time being this serves as a way to use typescript on location data. This will be useful for the map and detail components moving forward