### PR TITLE
Add All Artworks to Map

### DIFF
--- a/front-end/src/components/ArtworkDetail.vue
+++ b/front-end/src/components/ArtworkDetail.vue
@@ -1,9 +1,12 @@
 <template>
   <div class="artwork-detail">
     <h1>Artist: {{ props.artwork.Artist }}</h1>
-    <h2>Description: {{ props.artwork?.Description }}</h2>
+    <h4>Description: {{ props.artwork?.Description }}</h4>
     <img :src="imagesrc" alt="artwork image" />
-    <h3>Photographer: {{ props.artwork.Image?.Photographer }}</h3>
+    <h4>Photographer: {{ props.artwork.Image?.Photographer }}</h4>
+    <div v-if="props.artwork.Location">
+      <h4>Address: {{ props.artwork.Location.Address }}</h4>
+    </div>
   </div>
 </template>
 

--- a/front-end/src/components/LeafletMapProvider.vue
+++ b/front-end/src/components/LeafletMapProvider.vue
@@ -1,25 +1,20 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import type { SearchResultArray } from '../types';
-const searchResults = ref<SearchResultArray | null>();
+import type { MapArtwork } from '../types';
+const artworks = ref<Array<MapArtwork> | null>();
 
 async function fetchSearchResults() {
-  const url = new URL(`${import.meta.env.VITE_ARCHES_API_URL}/search/resources`);
-  const params = new URLSearchParams({
-    'paging-filter': '1',
-    'resource-type-filter': `[{"graphid":"${import.meta.env.VITE_ARTWORK_GRAPH_ID}","name":"Artwork","inverted":false}]`
-  });
-  url.search = params.toString();
+  const url = new URL(`${import.meta.env.VITE_ARCHES_API_URL}/archesdataviewer/artworks`);
 
   const response = await fetch(url.toString()).then((res) => res.json());
-  searchResults.value = { items: response.results.hits.hits };
+  artworks.value = response;
+  console.log(artworks.value);
 }
-
 fetchSearchResults();
 </script>
 
 <template>
-  <slot :searchResults="searchResults" />
+  <slot :artworks="artworks" />
 </template>
 
 <style scoped></style>

--- a/front-end/src/pages/HomePage.vue
+++ b/front-end/src/pages/HomePage.vue
@@ -23,6 +23,7 @@ import ResourcePanelProvider from '@/components/ResourcePanelProvider.vue';
     <div class="column" id="map-container">
       <LeafletMapProvider v-slot="{ artworks }">
         <LeafletMap :artworks="artworks" v-if="artworks" />
+        <div class="map-placeholder" v-else>Loading Map...</div>
       </LeafletMapProvider>
     </div>
     <div class="column" id="resource-panel-container">
@@ -45,6 +46,12 @@ import ResourcePanelProvider from '@/components/ResourcePanelProvider.vue';
   flex: 1;
   flex-direction: column;
   overflow-y: auto;
+}
+
+.map-placeholder{
+  margin-top:30vh;
+  text-align: center;
+  font-size: larger;
 }
 
 #search-list-container,

--- a/front-end/src/pages/HomePage.vue
+++ b/front-end/src/pages/HomePage.vue
@@ -21,8 +21,8 @@ import ResourcePanelProvider from '@/components/ResourcePanelProvider.vue';
       </SearchListProvider>
     </div>
     <div class="column" id="map-container">
-      <LeafletMapProvider v-slot="{ searchResults }">
-        <LeafletMap :search-results="searchResults" v-if="searchResults" />
+      <LeafletMapProvider v-slot="{ artworks }">
+        <LeafletMap :artworks="artworks" v-if="artworks" />
       </LeafletMapProvider>
     </div>
     <div class="column" id="resource-panel-container">

--- a/front-end/src/types/Artwork.ts
+++ b/front-end/src/types/Artwork.ts
@@ -21,6 +21,10 @@ export interface Artwork {
   Title: string;
 }
 
+export interface MapArtwork extends Artwork {
+  '@resource_id': string;
+}
+
 const ArtworkSchema: JSONSchemaType<Artwork> = {
   type: 'object',
   properties: {

--- a/front-end/src/types/Coordinates.ts
+++ b/front-end/src/types/Coordinates.ts
@@ -11,7 +11,6 @@ interface Feature {
   type: string;
   geometry: Geometry;
   properties: Properties;
-  feature_info_content: string;
 }
 
 interface Geometry {
@@ -50,10 +49,9 @@ const CoordinatesSchema: JSONSchemaType<Coordinates> = {
               nodeId: { type: 'string' }
             },
             required: ['nodeId']
-          },
-          feature_info_content: { type: 'string' }
+          }
         },
-        required: ['id', 'type', 'geometry', 'properties', 'feature_info_content']
+        required: ['id', 'type', 'properties']
       }
     }
   },

--- a/front-end/src/types/index.ts
+++ b/front-end/src/types/index.ts
@@ -3,4 +3,4 @@ export * from './Artist';
 export * from './Artwork';
 export * from './ResourceRelation';
 export * from './Resource';
-export * from './Coordinates'
+export * from './Coordinates';

--- a/front-end/src/utils.ts
+++ b/front-end/src/utils.ts
@@ -1,16 +1,17 @@
 import { validateCoordinatesSchema } from './types';
 import type { Coordinates } from './types';
 
-export function coordinatesStringToObject(coordinates: string): Coordinates {
+export function coordinatesStringToObject(coordinates: string): Coordinates | undefined {
   const validJsonString = coordinates.replace(/'/g, '"');
   try {
-    coordinates = JSON.parse(validJsonString);
-    if (validateCoordinatesSchema(coordinates)) {
-      return coordinates;
+    const parsedCoordinates = JSON.parse(validJsonString);
+
+    if (validateCoordinatesSchema(parsedCoordinates)) {
+      return parsedCoordinates;
     } else {
-      throw new Error('Coordinates JSON string invalid');
+      return undefined;
     }
   } catch (error) {
-    throw new Error('Failed to parse Coordinates JSON string');
+    throw new Error(`Failed to parse Coordinates JSON string:`);
   }
 }


### PR DESCRIPTION
This PR utilizes the newly added 'archesdataviewer/artworks' route in PR #9( and it's update in PR #10) for the map component in the application. Now, on application start, the map will fetch ALL artworks in the arches database and render them on the map. 