### PR TITLE
Add related resources view

### DIFF
--- a/front-end/src/components/ArtworkDetail.vue
+++ b/front-end/src/components/ArtworkDetail.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="artwork-detail">
-    <h1>Artist: {{ props.artwork.Artist }}</h1>
+    <h1>Title: {{ props.artwork.Title }}</h1>
+    <h2>Artist: {{ props.artwork.Artist }}</h2>
     <h4>Description: {{ props.artwork?.Description }}</h4>
     <img :src="imagesrc" alt="artwork image" />
     <h4>Photographer: {{ props.artwork.Image?.Photographer }}</h4>

--- a/front-end/src/components/ResourcePanel.vue
+++ b/front-end/src/components/ResourcePanel.vue
@@ -3,10 +3,12 @@ import { ref } from 'vue';
 import { validateArtistSchema, validateArtworkSchema } from '@/types';
 import ArtworkDetail from './ArtworkDetail.vue';
 import ArtistDetail from './ArtistDetail.vue';
-import type { Resource } from '@/types';
+import ResourceRelationList from './ResourceRelationList.vue';
+import type { Resource, ResourceRelation } from '@/types';
 
 const props = defineProps<{
   resource: Resource | undefined;
+  resourceRelations: Array<ResourceRelation> | undefined;
 }>();
 
 const showMetaData = ref<boolean>(false);
@@ -23,6 +25,7 @@ const showMetaData = ref<boolean>(false);
         :artist="props.resource.resource"
         v-else-if="validateArtistSchema(props.resource?.resource)"
       />
+      <ResourceRelationList :resourceRelations="resourceRelations" v-if="resourceRelations" />
       <button @click="showMetaData = !showMetaData">Show Arches Metadata</button>
       <div v-if="showMetaData">
         <ul>

--- a/front-end/src/components/ResourcePanelProvider.vue
+++ b/front-end/src/components/ResourcePanelProvider.vue
@@ -1,13 +1,14 @@
 <template>
-  <slot :resource="resource" />
+  <slot :resource="resource" :resourceRelations="resourceRelations" />
 </template>
 
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 import { useResourceStore } from '../stores/resourceStore';
-import type { Resource } from '@/types';
+import type { Resource, ResourceRelation } from '@/types';
 const store = useResourceStore();
 const resource = ref<Resource>();
+const resourceRelations = ref<Array<ResourceRelation>>();
 
 async function fetchResource() {
   if (!store.resourceId) return;
@@ -21,11 +22,21 @@ async function fetchResource() {
   resource.value = data;
 }
 
+async function fetchResourceRelations() {
+  if (!store.resourceId) return;
+  const url = new URL(
+    `${import.meta.env.VITE_ARCHES_API_URL}/resource/related/${store.resourceId}`
+  );
+  const response = await fetch(url.toString()).then((res) => res.json());
+  resourceRelations.value = response.related_resources.related_resources;
+}
+
 watch(
   () => store.resourceId,
   async (newResourceId) => {
     if (newResourceId) {
-      await fetchResource();
+      fetchResource();
+      fetchResourceRelations();
     }
   },
   { immediate: true }

--- a/front-end/src/components/ResourceRelationItem.vue
+++ b/front-end/src/components/ResourceRelationItem.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="resource-relation-item" @click="setResource">
+    <p>Name: {{ props.resourceRelation.displayname }}</p>
+    <p>Description: {{ props.resourceRelation.displaydescription }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ResourceRelation } from '../types';
+const emit = defineEmits(['set-resource']);
+
+const props = defineProps<{
+  resourceRelation: ResourceRelation;
+}>();
+
+const setResource = () => {
+  emit('set-resource', props.resourceRelation.resourceinstanceid);
+};
+</script>
+
+<style scoped>
+.resource-relation-item {
+  border: 2px solid black;
+  margin: 10px;
+}
+.resource-relation-item:hover {
+  opacity: 50%;
+}
+</style>

--- a/front-end/src/components/ResourceRelationList.vue
+++ b/front-end/src/components/ResourceRelationList.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import ResourceRelationItem from './ResourceRelationItem.vue';
+import type { ResourceRelation } from '../types';
+import { useResourceStore } from '@/stores/resourceStore';
+
+const store = useResourceStore();
+
+const props = defineProps<{
+  resourceRelations: Array<ResourceRelation>;
+}>();
+
+const setResource = (resourceId: string) => {
+  store.$patch({
+    resourceId: resourceId
+  });
+};
+</script>
+
+<template>
+  <div class="resource-relation-list-container">
+    <h4>Related Resources:</h4>
+    <div class="resource-relation-list" v-if="props.resourceRelations">
+      <ResourceRelationItem
+        v-for="resourceRelation in props.resourceRelations"
+        :resource-relation="resourceRelation"
+        :key="resourceRelation.resourceinstanceid"
+        @set-resource="setResource"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/front-end/src/pages/HomePage.vue
+++ b/front-end/src/pages/HomePage.vue
@@ -27,8 +27,8 @@ import ResourcePanelProvider from '@/components/ResourcePanelProvider.vue';
       </LeafletMapProvider>
     </div>
     <div class="column" id="resource-panel-container">
-      <ResourcePanelProvider v-slot="{ resource }">
-        <ResourcePanel :resource="resource" />
+      <ResourcePanelProvider v-slot="{ resource, resourceRelations }">
+        <ResourcePanel :resource="resource" :resource-relations="resourceRelations" />
       </ResourcePanelProvider>
     </div>
   </div>
@@ -48,8 +48,8 @@ import ResourcePanelProvider from '@/components/ResourcePanelProvider.vue';
   overflow-y: auto;
 }
 
-.map-placeholder{
-  margin-top:30vh;
+.map-placeholder {
+  margin-top: 30vh;
   text-align: center;
   font-size: larger;
 }

--- a/front-end/src/types/ResourceRelation.ts
+++ b/front-end/src/types/ResourceRelation.ts
@@ -1,43 +1,8 @@
-import type { Point, MapPopup, Geometry, ResourcePermissions } from './SearchResult';
-
-interface RelationIds {
-  id: string;
-  nodegroup_id: string;
-  provisional: boolean;
-}
-
-interface RelationDomain {
-  conceptid: string;
-  label: string;
-  nodegroup_id: string;
-  provisional: boolean;
-  valueid: string;
-}
-
 interface ResourceRelation {
-  date_ranges: string[];
-  dates: string[];
   displaydescription: string;
   displayname: string;
-  domains: RelationDomain[];
-  geometries: Geometry[];
-  graph_id: string;
-  ids: RelationIds[];
-  legacyid: null;
-  map_popup: MapPopup[];
-  numbers: any[];
-  permissions: ResourcePermissions;
-  points: Point[];
-  provisional_resource: string;
   resourceinstanceid: string;
-  root_ontology_class: string;
-  strings?: any;
-  tiles?: any;
-  total_relations: number;
+  graph_id: string;
 }
 
-interface ResourceRelationArray {
-  items: ResourceRelation[];
-}
-
-export type { ResourceRelation, ResourceRelationArray };
+export type { ResourceRelation };


### PR DESCRIPTION
This PR adds to the existing resource detail panel a list of related resources, as determined by querying the 'resource/related/<id>' endpoint in base arches. It enables the user to see basic data about the related resource, and on-click, bring up the full detail page of the related resource.