### PR TITLE
Fix getimage route

### DIFF
--- a/archesdataviewer/views.py
+++ b/archesdataviewer/views.py
@@ -13,10 +13,8 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer
 graphs_prefetch = models.GraphModel.objects.all()
 name_to_graph_table = {str(gr_obj.name): gr_obj for gr_obj in graphs_prefetch}
 
-# This is a prefetch done to the Node model to allow for lookup of tiles
-# based on node name
-nodes_prefetch = models.Node.objects.all()
-name_to_node_table = {str(n_obj.name): n_obj for n_obj in nodes_prefetch}
+# This is a hardcoded id for the image node
+image_node_id = UUID('51502cdc-505b-11ee-be94-869ad5966fc6')
 
 
 def index(request):
@@ -61,10 +59,10 @@ def getImage(request,resource_id):
         # Fetch a list of ids of all resources that are related to the artist
         relations = models.ResourceXResource.objects.filter(resourceinstanceidto_id=UUID(resource_id), resourceinstancefrom_graphid_id=name_to_graph_table["Artwork"].graphid).values_list('resourceinstanceidfrom_id',flat=True)
         # Extract all tiles in the 'Image' NodeGroup that have a resourceId in the related artworks
-        tiles = models.TileModel.objects.filter(nodegroup_id=name_to_node_table['Image'].nodegroup_id,resourceinstance_id__in=relations)
+        tiles = models.TileModel.objects.filter(nodegroup_id=image_node_id,resourceinstance_id__in=relations)
     elif resource.graph_id == name_to_graph_table["Artwork"].graphid:
         # An artwork should implicitly only have one image directly related to it 
-        tiles = models.TileModel.objects.filter(nodegroup_id=name_to_node_table['Image'].nodegroup_id,resourceinstance_id=UUID(resource_id))
+        tiles = models.TileModel.objects.filter(nodegroup_id=image_node_id,resourceinstance_id=UUID(resource_id))
     return JSONResponse(tiles)
 
 


### PR DESCRIPTION
This commit fixes an issue with the getimage route wherein the proper nodegroup id for an image in an artwork was being lost.  Since there is no limit in arche for how many nodes can be named 'Image', this commit instead hardcodes the desired nodeid into the route.