### PR TITLE
Accommodate WAC canonical data changes

### DIFF
--- a/archesdataviewer/views.py
+++ b/archesdataviewer/views.py
@@ -13,8 +13,13 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer
 graphs_prefetch = models.GraphModel.objects.all()
 name_to_graph_table = {str(gr_obj.name): gr_obj for gr_obj in graphs_prefetch}
 
-# This is a hardcoded id for the image node
-image_node_id = UUID('51502cdc-505b-11ee-be94-869ad5966fc6')
+# This is a hardcoded id for the photographer node group id
+photographer_node_group_id = UUID('5f85f884-34a5-11ef-9840-525400ef2e2d')
+
+# This is a hardcoded id for the image node id
+image_node_id = '73924468-34a5-11ef-bb6e-525400ef2e2d'
+
+
 
 
 def index(request):
@@ -58,12 +63,13 @@ def getImage(request,resource_id):
     if resource.graph_id == name_to_graph_table["Artist"].graphid:
         # Fetch a list of ids of all resources that are related to the artist
         relations = models.ResourceXResource.objects.filter(resourceinstanceidto_id=UUID(resource_id), resourceinstancefrom_graphid_id=name_to_graph_table["Artwork"].graphid).values_list('resourceinstanceidfrom_id',flat=True)
-        # Extract all tiles in the 'Image' NodeGroup that have a resourceId in the related artworks
-        tiles = models.TileModel.objects.filter(nodegroup_id=image_node_id,resourceinstance_id__in=relations)
+        # Extract all tiles in the 'Photographer' NodeGroup that have a resourceId in the related artworks
+        tiles = models.TileModel.objects.filter(nodegroup_id=photographer_node_group_id,resourceinstance_id__in=relations)
+        
     elif resource.graph_id == name_to_graph_table["Artwork"].graphid:
         # An artwork should implicitly only have one image directly related to it 
-        tiles = models.TileModel.objects.filter(nodegroup_id=image_node_id,resourceinstance_id=UUID(resource_id))
-    return JSONResponse(tiles)
+        tiles = models.TileModel.objects.filter(nodegroup_id=photographer_node_group_id,resourceinstance_id=UUID(resource_id))
+    return JSONResponse(tiles[0].data[image_node_id][0])
 
 
 

--- a/front-end/src/components/ArtworkDetail.vue
+++ b/front-end/src/components/ArtworkDetail.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="artwork-detail">
-    <h1>Title: {{ props.artwork.Title || 'N/A' }}</h1>
-    <h2>Artist: {{ props.artwork.Artist || 'N/A' }}</h2>
-    <h4>Description: {{ props.artwork?.Description || 'N/A' }}</h4>
-    <img v-if="imagesrc" :src="imagesrc" alt="artwork image" @click="showModal = true" />
-    <h4>Photographer: {{ props.artwork.Image?.Photographer || 'N/A' }}</h4>
+    <h1>Title: {{ props.artwork.Title }}</h1>
+    <h2>Artist: {{ props.artwork.Artist }}</h2>
+    <h4>Description: {{ props.artwork?.Description }}</h4>
+    <a :href="imagesrc"><img :src="imagesrc" alt="artwork image" /></a>
+    <h4>Photographer: {{ props.artwork.Photograph?.Photographer }}</h4>
     <div v-if="props.artwork.Location">
-      <h4>Address: {{ props.artwork.Location.Address || 'N/A' }}</h4>
+      <h4>Address: {{ props.artwork.Location['Located On'] }}</h4>
     </div>
     <Modal :visible="showModal" @update:visible="showModal = $event">
       <img :src="imagesrc" alt="Expanded artwork image" class="expanded-image" @click="showModal = false" />
@@ -26,8 +26,8 @@ const props = defineProps<{
 const showModal = ref(false);
 
 const imagesrc = computed(() => {
-  if (props.artwork.Image) {
-    return `${import.meta.env.VITE_ARCHES_API_URL}${props.artwork.Image['@value']}`;
+  if (props.artwork.Photograph) {
+    return `${import.meta.env.VITE_ARCHES_API_URL}${props.artwork.Photograph.Image}`;
   } else {
     return '';
   }

--- a/front-end/src/components/LeafletMap.vue
+++ b/front-end/src/components/LeafletMap.vue
@@ -39,7 +39,7 @@ const initMap = (element: HTMLElement) => {
             coordinate.features[0].geometry.coordinates[0]
           ]);
           marker.bindPopup(`<b>Artwork Title: ${value.Title}</b><br>
-          By: ${value.Artist}<br> ${value.Location.Address}`);
+          By: ${value.Artist}<br> ${value.Location.Coordinates}`);
           marker.on('click', () => {
             store.$patch({
               resourceId: value['@resource_id']

--- a/front-end/src/components/ResourceListItem.vue
+++ b/front-end/src/components/ResourceListItem.vue
@@ -32,7 +32,7 @@ async function fetchImage() {
     `${import.meta.env.VITE_ARCHES_API_URL}/archesdataviewer/getimage/${props.resourceId}`
   );
   const response = await fetch(url.toString()).then((res) => res.json());
-  const imagePath = response[0]?.data[response[0]?.nodegroup_id][0].url;
+  const imagePath = response?.url;
   if (imagePath) {
     imageUrl.value = import.meta.env.VITE_ARCHES_API_URL + imagePath;
   }

--- a/front-end/src/types/Artwork.ts
+++ b/front-end/src/types/Artwork.ts
@@ -3,20 +3,15 @@ import { ajv } from '@/ajv';
 
 export interface Artwork {
   Artist: string;
-  Identifiers: {
-    ID: string;
-    'ID Type': string;
-  };
-  Image: {
-    '@value': string;
+  Photograph: {
+    Image: string;
     Photographer: string;
   };
   Location: {
-    Address: string;
     Coordinates?: string;
-    'Location Description': string;
-    Structure: string;
+    'Located On': string;
   };
+  Medium: string;
   Description?: string;
   Title: string;
 }
@@ -30,35 +25,28 @@ const ArtworkSchema: JSONSchemaType<Artwork> = {
   properties: {
     Artist: { type: 'string' },
     Description: { type: 'string', nullable: true },
-    Identifiers: {
+    Photograph: {
       type: 'object',
       properties: {
-        ID: { type: 'string' },
-        'ID Type': { type: 'string' }
-      },
-      required: ['ID', 'ID Type']
-    },
-    Image: {
-      type: 'object',
-      properties: {
-        '@value': { type: 'string' },
+        Image: { type: 'string' },
         Photographer: { type: 'string' }
       },
-      required: ['@value', 'Photographer']
+      required: ['Image', 'Photographer']
     },
     Location: {
       type: 'object',
       properties: {
-        Address: { type: 'string' },
         Coordinates: { type: 'string', nullable: true },
-        'Location Description': { type: 'string' },
-        Structure: { type: 'string' }
+        'Located On': { type: 'string' }
       },
-      required: ['Address', 'Location Description', 'Structure']
+      required: ['Located On']
+    },
+    Medium: {
+      type: 'string'
     },
     Title: { type: 'string' }
   },
-  required: ['Artist', 'Identifiers', 'Title'],
+  required: ['Artist', 'Title', 'Location'],
   additionalProperties: true
 };
 


### PR DESCRIPTION
This commit updates the repository to accommodate the latest changes to the canonical wac dataset, now hosted here
https://code.librehq.com/ots/arches/arches-demo-data. These changes are principally reflected in the refactor of the Artwork resource type, and the getImage route (as the canonical node ids for an artworks image url file has changed). Thankfully, since the Resource typescript types were designed to contain only data shared across all arches resources, we do not need to do any more refactoring than the datatypes that we ourselves define.

One non-breaking change is that since the canonical dataset does not currently provide geojson data for Artworks, the map component in the vue application does not render any artworks. However, as soon as we do add geojson back to the artworks, it will render.