### PR TITLE
Add Basic Search Functionality

### DIFF
--- a/front-end/eslint.config.js
+++ b/front-end/eslint.config.js
@@ -10,15 +10,23 @@ export default tseslint.config(
   ...pluginVue.configs['flat/recommended'],
   {
     plugins: {
-      'typescript-eslint': tseslint.plugin,
+      'typescript-eslint': tseslint.plugin
     },
     languageOptions: {
       parserOptions: {
         parser: tseslint.parser,
         extraFileExtensions: ['.vue'],
-        sourceType: 'module',
-      },
+        sourceType: 'module'
+      }
     },
+    rules: {
+      'vue/no-mutating-props': [
+        'error',
+        {
+          shallowOnly: true
+        }
+      ]
+    }
   },
-  eslintConfigPrettier,
+  eslintConfigPrettier
 );

--- a/front-end/src/App.vue
+++ b/front-end/src/App.vue
@@ -14,12 +14,12 @@ const graphTable = ref<Map<string, string>>(new Map());
 async function fetchGraphTable() {
   const url = new URL(`${import.meta.env.VITE_ARCHES_API_URL}/archesdataviewer/graphs`);
   const response: Graph[] = await fetch(url.toString()).then((res) => res.json());
-
   const map = new Map<string, string>();
   response.forEach((item) => {
-    map.set(item.graphid, item.name);
+    if (item.name !== 'Arches System Settings') {
+      map.set(item.graphid, item.name);
+    }
   });
-
   graphTable.value = map;
 }
 

--- a/front-end/src/components/SearchList.vue
+++ b/front-end/src/components/SearchList.vue
@@ -1,5 +1,18 @@
 <template>
   <div class="search-list-container">
+    <div class="search-bar">
+      <input
+        v-model="props.searchQuery.resourceName"
+        class="search-input"
+        placeholder="Search by name..."
+      />
+      <select v-model="props.searchQuery.resourceGraphId" class="search-select">
+        <option disabled value="">Please select one</option>
+        <option v-for="(value, id) in props.graphTable" :key="id" :value="value[0]">
+          {{ value[1] }}
+        </option>
+      </select>
+    </div>
     <div class="search-list">
       <ResourceListItem
         v-for="result in props.searchResults.items"
@@ -27,6 +40,7 @@ import { useResourceStore } from '@/stores/resourceStore';
 import type { SearchResultArray } from '../types';
 import ResourceListItem from './ResourceListItem.vue';
 import SearchListButton from './SearchListButton.vue';
+
 const store = useResourceStore();
 const props = defineProps<{
   pageValues: {
@@ -35,6 +49,10 @@ const props = defineProps<{
   };
   searchResults: SearchResultArray;
   graphTable: Map<string, string>;
+  searchQuery: {
+    resourceName: Ref<string>;
+    resourceGraphId: Ref<string>;
+  };
 }>();
 
 const emit = defineEmits(['next-page', 'previous-page']);
@@ -58,6 +76,33 @@ const setResource = (resourceId: string) => {
   display: flex;
   flex-direction: column;
   height: 100%;
+}
+
+.search-bar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  padding: 20px;
+  background-color: var(--color-light-grey);
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+
+.search-input {
+  padding: 10px;
+  font-size: 16px;
+  border: 1px solid var(--color-grey);
+  border-radius: 4px;
+  width: 300px;
+}
+
+.search-select {
+  padding: 10px;
+  font-size: 16px;
+  border: 1px solid var(--color-grey);
+  border-radius: 4px;
+  width: 200px;
 }
 
 .search-list {

--- a/front-end/src/components/SearchListProvider.vue
+++ b/front-end/src/components/SearchListProvider.vue
@@ -1,16 +1,43 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { reactive, ref, watch } from 'vue';
 import type { SearchResultArray } from '../types';
+
 const page = ref(1);
 const searchResults = ref<SearchResultArray | null>();
 const has_next = ref(true);
 const has_previous = ref(false);
+const searchQuery = reactive({ resourceName: '', resourceGraphId: '' });
 
-async function fetchSearchResults() {
+const props = defineProps<{
+  graphTable: Map<string, string>;
+}>();
+
+interface fetchSearchResultsProps {
+  resourceName?: string;
+  resourceGraphId?: string;
+}
+
+async function fetchSearchResults({ resourceName, resourceGraphId }: fetchSearchResultsProps = {}) {
   const url = new URL(`${import.meta.env.VITE_ARCHES_API_URL}/search/resources`);
+
   const params = new URLSearchParams({
     'paging-filter': page.value.toString()
   });
+
+  if (resourceName) {
+    params.append(
+      'term-filter',
+      `[{"inverted":false,"type":"string","context":"","context_label":"","id":"${resourceName}","text":"${resourceName}","value":"${resourceName}","selected":true}]`
+    );
+  }
+
+  if (resourceGraphId) {
+    params.append(
+      'resource-type-filter',
+      `[{"graphid":"${resourceGraphId}","name":"${props.graphTable.get(resourceGraphId)}","inverted":false}]`
+    );
+  }
+
   url.search = params.toString();
 
   const response = await fetch(url.toString()).then((res) => res.json());
@@ -19,12 +46,12 @@ async function fetchSearchResults() {
   searchResults.value = { items: response.results.hits.hits };
 }
 
-fetchSearchResults();
+fetchSearchResults(searchQuery);
 
 const fetchNextPage = () => {
   if (has_next.value) {
     page.value++;
-    fetchSearchResults();
+    fetchSearchResults(searchQuery);
   } else {
     has_next.value = false;
   }
@@ -33,11 +60,23 @@ const fetchNextPage = () => {
 const fetchPreviousPage = () => {
   if (has_previous.value) {
     page.value--;
-    fetchSearchResults();
+    fetchSearchResults(searchQuery);
   } else {
     has_previous.value = false;
   }
 };
+
+watch(
+  () => ({ resourceGraphId: searchQuery.resourceGraphId, resourceName: searchQuery.resourceName }),
+  async (newQuery) => {
+    try {
+      await fetchSearchResults(newQuery);
+    } catch (error) {
+      console.error('Unhandled error during execution of watcher callback', error);
+    }
+  },
+  { deep: true, immediate: true }
+);
 
 const pageValues = {
   has_next: has_next,
@@ -51,6 +90,7 @@ const pageValues = {
     :fetch-next-page="fetchNextPage"
     :fetch-previous-page="fetchPreviousPage"
     :page-values="pageValues"
+    :search-query="searchQuery"
   />
 </template>
 

--- a/front-end/src/pages/HomePage.vue
+++ b/front-end/src/pages/HomePage.vue
@@ -1,12 +1,16 @@
 <template>
   <div class="home">
     <div id="search-list-container" class="column">
-      <SearchListProvider v-slot="{ searchResults, fetchNextPage, fetchPreviousPage, pageValues }">
+      <SearchListProvider
+        v-slot="{ searchResults, fetchNextPage, fetchPreviousPage, pageValues, searchQuery }"
+        :graph-table="props.graphTable"
+      >
         <SearchList
           v-if="searchResults"
           :search-results="searchResults"
           :page-values="pageValues"
           :graph-table="props.graphTable"
+          :search-query="searchQuery"
           @next-page="fetchNextPage"
           @previous-page="fetchPreviousPage"
         />

--- a/front-end/vite.config.ts
+++ b/front-end/vite.config.ts
@@ -1,7 +1,7 @@
-import { fileURLToPath, URL } from 'node:url'
+import { fileURLToPath, URL } from 'node:url';
 
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,9 +11,12 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
   },
+  server: {
+    port: 3000
+  },
   build: {
     outDir: '../archesdataviewer/static/vite_build',
     emptyOutDir: true,
-    manifest: true,
+    manifest: true
   }
-})
+});


### PR DESCRIPTION
This commit adds a rudimentary search capability to the searchlist component, which allows for resource retrieval by name or resource model type. This is done via calls to the elasticsearch node using the same `/search/resources` route already being used by the component. A new search is made on each keystroke which could have scaling issues in the future, but elastic search seems to be able to maintain [1]. As arches is serving as a connector to the elasticsearch node, it will do good to further conform to elasticsearch design patterns as we develop search on the frontend

[1]https://www.elastic.co/guide/en/elasticsearch/reference/current/search-as-you-type.html