### PR TITLE
Replace Inter font with native system font stack

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -8,7 +8,6 @@
       "name": "front-end",
       "version": "0.0.0",
       "dependencies": {
-        "@fontsource-variable/inter": "^5.1.0",
         "@heroicons/vue": "^2.1.5",
         "@vue/eslint-config-airbnb-with-typescript": "^8.0.0",
         "ajv": "^8.17.1",
@@ -550,11 +549,6 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
-    },
-    "node_modules/@fontsource-variable/inter": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.1.0.tgz",
-      "integrity": "sha512-Wj2dUGP0vUpxRGQTXQTCNJO+aLcFcQm+gUPXfj/aS877bQkEPBPv9JvZJpwdm2vzelt8NTZ+ausKlBCJjh2XIg=="
     },
     "node_modules/@heroicons/vue": {
       "version": "2.1.5",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -16,7 +16,6 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "@fontsource-variable/inter": "^5.1.0",
     "@heroicons/vue": "^2.1.5",
     "@vue/eslint-config-airbnb-with-typescript": "^8.0.0",
     "ajv": "^8.17.1",

--- a/front-end/src/assets/base.css
+++ b/front-end/src/assets/base.css
@@ -61,7 +61,8 @@
 }
 
 body {
-  font-family: 'Inter Variable', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial,
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
   font-size: var(--wac--font-size);
   line-height: var(--wac--line-height);
   background-color: white;

--- a/front-end/src/main.ts
+++ b/front-end/src/main.ts
@@ -1,4 +1,3 @@
-import '@fontsource-variable/inter';
 import './assets/main.css';
 import { createApp } from 'vue';
 import router from './router';


### PR DESCRIPTION
After struggling to get a Fontsource-provided font to serve correctly in production using our Vite build process, I decided to re-evaluate our need to even use a custom font. Turns out it wasn’t doing us enough good to justify either the development time struggling with this *or* the user experience cost with custom fonts.

This PR:

- Switches from Inter to the GitHub/Bootstrap-style native font stack
- Removes the Fontsource package

Replaces #101 
Closes #100